### PR TITLE
Stop unauthorized and redundant installs of the "newspaper" library

### DIFF
--- a/gnews/gnews.py
+++ b/gnews/gnews.py
@@ -1,13 +1,18 @@
 import logging
 import os
+import sys
 import urllib.request
 
 import feedparser
 from bs4 import BeautifulSoup as Soup
 from dotenv import load_dotenv
+try:
+    import newspaper  # Optional - required by GNews.get_full_article()
+except ImportError:
+    pass
 
 from gnews.utils.constants import AVAILABLE_COUNTRIES, AVAILABLE_LANGUAGES, TOPICS, BASE_URL, USER_AGENT
-from gnews.utils.utils import connect_database, post_database, import_or_install, process_url
+from gnews.utils.utils import connect_database, post_database, process_url
 
 logging.basicConfig(format='%(asctime)s - %(message)s', level=logging.INFO,
                     datefmt='%m/%d/%Y %I:%M:%S %p')
@@ -98,15 +103,18 @@ class GNews:
 
     def get_full_article(self, url):
         """
-        It takes a URL as an argument, downloads the article, parses it, and returns the article object
+        Download an article from the specified URL, parse it, and return an article object.
 
-        :param url: The URL of the article you want to summarize
-        :return: The article object from newspaper3k.
+        :param url: The URL of the article you wish to summarize.
+        :return: An `Article` object returned by the `newspaper` library.
         """
+        # Check if the `newspaper` library is available
+        if 'newspaper' not in (sys.modules.keys() & globals()):  # Top import failed since it's not installed
+            print("\nget_full_article() requires the `newspaper` library.")
+            print("You can install it by running `python3 -m pip install newspaper3k` in your shell.\n")
+            return None
         try:
-            import_or_install('newspaper3k')
-            from newspaper import Article
-            article = Article(url="%s" % url, language=self._language)
+            article = newspaper.Article(url="%s" % url, language=self._language)
             article.download()
             article.parse()
         except Exception as error:

--- a/gnews/utils/utils.py
+++ b/gnews/utils/utils.py
@@ -3,13 +3,10 @@ import json
 import logging
 import re
 
-import pip
 import pymongo
 import requests
+from gnews.utils.constants import AVAILABLE_COUNTRIES, AVAILABLE_LANGUAGES, GOOGLE_NEWS_REGEX
 from pymongo import MongoClient
-
-from gnews.utils.constants import AVAILABLE_LANGUAGES, AVAILABLE_COUNTRIES, GOOGLE_NEWS_REGEX
-
 
 
 def lang_mapping(lang):
@@ -18,16 +15,6 @@ def lang_mapping(lang):
 
 def country_mapping(country):
     return AVAILABLE_COUNTRIES.get(country)
-
-
-def import_or_install(package):
-    try:
-        __import__(package)
-    except ImportError:
-        if hasattr(pip, 'main'):
-            pip.main(['install', package])
-        else:
-            pip._internal.main(['install', package])
 
 
 def connect_database(db_user, db_pw, db_name, collection_name):


### PR DESCRIPTION
The call to utils.import_or_install() introduced several issues:

- It was called with the parameter "newspaper3k". Since the correct import
  name is "newspaper" ("newspaper3k" is used for installation purposes),
  the __import __ call always failed, which means every call to the
  get_full_article() method would result in a redundant "pip install"
  process starting.

- Just to reiterate: Every user of this library right now sees a long
  and cryptic pip install output message WITH EACH AND EVERY CALL they
  make to get_full_article().

- Installing pip packages and/or modifying a user's environment without
  permission or any indication of such behavior (nothing in the docs)
  is unacceptable.

- Installing packages using direct calls to pip module internals
  is NOT the way to install packages and also yields warnings regarding
  the usage of incorrect pip wrappers.

