### PR TITLE
Streamlined workflows by minimizing clutter.

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -16,8 +16,8 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Set up Python
-      uses: actions/setup-python@v2
+    - name: Set up Python 3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,12 +1,11 @@
-# This workflow will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+# This workflow will upload a Python Package using Twine when a release is created.
 
 name: Upload Python Package
 
 on:
-  push:
-    branches:
-      - master
+  workflow_dispatch:
+  release:
+    types: [published]
 
 jobs:
   deploy:
@@ -14,19 +13,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v3
+
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: '3.x'
+
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python setup.py sdist bdist_wheel
-        twine upload --skip-existing dist/*
+        pip install -U pip
+        pip install build
+
+    - name: Build package
+      run: python -m build
+
+    - name: Publish
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## ⚔️ Things changed:

This PR primarily focuses on `.github/workflows/python-publish.yml`.

- The workflow now only triggers upon manual dispatch / a successful published release (which the comments at the beginning said that it did but actually didn't).

- The PyPI publish workflow doesn't require multiple dependencies / commands to be set up anymore. The build job uses the `build` Python package and the publishing workflow has been changed to [the official one](https://github.com/marketplace/actions/pypi-publish) provided by the Python Packaging Authority.

- Bumped dependency version for checking out source code.

- Bumped dependency version for setting up Python.

## 🔖 To make this work:

Since the publishing workflow has been changed, you will need to remove these secrets from the repository:

- `PYPI_USERNAME`
- `PYPI_PASSWORD`

... and replace them with `PYPI_API_TOKEN`. This secret will contain a token provided by PyPI itself, which you can get from the **Manage** page of your project by clicking on "Create a token for project-name".

I hope this helps :D