### PR TITLE
Bump python-dotenv

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ bs4~=0.0.1
 beautifulsoup4~=4.9.3
 pymongo~=3.12.0
 dnspython~=1.16.0
-python-dotenv~=0.19.0
+python-dotenv>=0.19.0
 requests==2.26.0

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r") as fh:
 setup(
     name='gnews',
     version='0.3.6',
-    # setup_requires=['setuptools_scm'],  
+    # setup_requires=['setuptools_scm'],
     # use_scm_version={
     #     "local_scheme": "no-local-version"
     # },
@@ -31,7 +31,6 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
python-dotenv was restricted to a fairly old version which caused dependency resolution problems when installed with packages requiring fairly new versions.

The Python 3.7 classifier was dropped because python-dotenv dropped support for 3.7.