### PR TITLE
add _get_final_url method

### DIFF
--- a/gnews/utils/utils.py
+++ b/gnews/utils/utils.py
@@ -75,3 +75,16 @@ def process_url(item, exclude_websites):
     if re.match(GOOGLE_NEWS_REGEX, url):
         url = requests.head(url).headers.get('location', url)
     return url
+
+@staticmethod
+def _get_final_url(url):
+    try:
+        headers = {
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Safari/537.36'
+        }
+        response = requests.get(url, headers=headers)
+        final_url = response.url
+        return final_url
+    except requests.RequestException as e:
+        logging.error(f"Request failed: {e}")
+        return None


### PR DESCRIPTION
current url in get_news method's return dict is orig google redirect url,
it takes time for fetching the full article, added a simple method to get the final url.
it could be used in get_news later
