### PR TITLE
Loosen constraints on requests and bs4 versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 feedparser~=6.0.2
-bs4~=0.0.1
-beautifulsoup4~=4.9.3
+beautifulsoup4>=4.9.3,<5
 pymongo~=3.12.0
 dnspython~=1.16.0
 python-dotenv>=0.19.0
-requests==2.26.0
+requests>=2.26.0,<3


### PR DESCRIPTION
Thanks for writing this package! It's been helpful.

This PR relaxes the constraints on requests and bs4, as these conflict with other packages and it doesn't seem that there are any breaking changes that would affect this project:

- https://requests.readthedocs.io/en/latest/community/updates/#release-history
- https://git.launchpad.net/beautifulsoup/tree/CHANGELOG

The test workflow still passes with the relaxed constraints.
N.B. I removed the bs4==0.0.1 dep because it's just a dummy for beautifulsoup4.