### PR TITLE
updated requirements.txt: removed dnspython version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 feedparser~=6.0.2
 beautifulsoup4>=4.9.3,<5
-dnspython~=1.16.0
+dnspython
 requests


### PR DESCRIPTION
I removed the check on the specific dnspython version as version 2 is out since a while. For instance, it conflicts when I try to use together with fastapi, receiving this error:

ERROR: Cannot install email-validator==2.1.1 and fastapi because these package versions have conflicting dependencies.

The conflict is caused by:
    gnews 0.3.7 depends on dnspython~=1.16.0
    email-validator 2.1.1 depends on dnspython>=2.0.0