### PR TITLE
fix: modify method name consistently with 5dff304

### DIFF
--- a/gnews/gnews.py
+++ b/gnews/gnews.py
@@ -234,7 +234,7 @@ class GNews:
         """
         if key:
             if self._max_results > 100:
-                return self._get_more_than_100(key)
+                return self._get_news_more_than_100(key)
             
             key = "%20".join(key.split(" "))
             query = '/search?q={}'.format(key)


### PR DESCRIPTION
https://github.com/ranahaani/GNews/commit/5dff304b788c935f8fd1bf964f3469d170ecb498
If the previous modifier didn't intentionally try not to use it, I think it should be corrected