### PR TITLE
feat: Enhance proxy support for GNews and URL processing

### DIFF
--- a/gnews/gnews.py
+++ b/gnews/gnews.py
@@ -41,7 +41,7 @@ class GNews:
         self.end_date = self.end_date = end_date
         self._start_date = self.start_date = start_date
         self._exclude_websites = exclude_websites if exclude_websites and isinstance(exclude_websites, list) else []
-        self._proxy = {'http': proxy, 'https': proxy} if proxy else None
+        self._proxy = proxy if proxy else None
 
     def _ceid(self):
         time_query = ''
@@ -199,7 +199,7 @@ class GNews:
         return text
 
     def _process(self, item):
-        url = process_url(item, self._exclude_websites)
+        url = process_url(item, self._exclude_websites, self._proxy)
         if url:
             title = item.get("title", "")
             item = {

--- a/gnews/utils/utils.py
+++ b/gnews/utils/utils.py
@@ -15,12 +15,15 @@ def country_mapping(country):
     return AVAILABLE_COUNTRIES.get(country)
 
 
-def process_url(item, exclude_websites):
+def process_url(item, exclude_websites, proxies=None):
     source = item.get('source').get('href')
     if not all([not re.match(website, source) for website in
                 [f'^http(s)?://(www.)?{website.lower()}.*' for website in exclude_websites]]):
         return
     url = item.get('link')
     if re.match(GOOGLE_NEWS_REGEX, url):
-        url = requests.head(url).headers.get('location', url)
+        if proxies:
+            url = requests.head(url, proxies=proxies).headers.get('location', url)
+        else:
+            url = requests.head(url).headers.get('location', url)
     return url


### PR DESCRIPTION
This commit introduces comprehensive proxy support for the GNews library, ensuring all external HTTP requests respect configured proxy settings.

fix: #113 

Key changes include:
- **`GNews` class initialization (`__init__`):** The `_proxy` attribute now directly accepts the `proxy` object passed during initialization. This streamlines proxy configuration by removing the implicit conversion to `{'http': proxy, 'https': proxy}`, making the proxy handling more flexible and aligned with `requests` library's expectations for a `proxies` dictionary.
- **`process_url` function:** Modified to accept a `proxies` argument, allowing `requests.head` to use the provided proxy for resolving Google News redirect URLs. This ensures external links are correctly followed even when a proxy is required.
- **`_process` method:** Updated to pass the `self._proxy` directly to the `process_url` function, ensuring the proxy setting is consistently applied throughout the news processing pipeline.

These modifications improve the reliability of news fetching in environments requiring proxy usage and enhance the library's overall network flexibility.