### PR TITLE
Feature: URL Encoding for get_news and get_news_by_location

### DIFF
--- a/gnews/gnews.py
+++ b/gnews/gnews.py
@@ -236,6 +236,7 @@ class GNews:
             if self._max_results > 100:
                 return self._get_news_more_than_100(key)
             
+            key = urllib.parse.quote(key)
             key = "%20".join(key.split(" "))
             query = '/search?q={}'.format(key)
             return self._get_news(query)

--- a/gnews/gnews.py
+++ b/gnews/gnews.py
@@ -331,6 +331,7 @@ class GNews:
         ..To implement date range try get_news('location')
         """
         if location:
+            location = urllib.parse.quote(location)
             query = '/headlines/section/geo/' + location + '?'
             return self._get_news(query)
         logger.warning("Enter a valid location.")

--- a/tests/test_gnews.py
+++ b/tests/test_gnews.py
@@ -28,7 +28,7 @@ class TestGNews(unittest.TestCase):
 
     def test_get_news_by_location(self):
         # Test that get_news_by_location returns a non-empty list of news articles for a valid location
-        location = "India"
+        location = "WORLD"
         news_articles = self.gnews.get_news_by_location(location)
         self.assertTrue(isinstance(news_articles, list))
         self.assertTrue(len(news_articles) > 0)


### PR DESCRIPTION
Description:
This PR adds URL encoding for user provided strings for GNews.get_news() and GNews.get_news_by_location(), because their searches can sometimes contain characters that do not work with URLs, as shown in issue #149, where the user was not getting any relevant stories for the S&P 500 Index.

Files Changed:
- gnews.py (added urllib.parse.quote() to user provided strings)
- test_gnews.py (updated test_get_news_by_location because "India" was returning no news but other locations were. Not an issue with the parsing) 

Tests:
```
test_get_full_article (test_gnews.TestGNews) ... ok
test_get_news (test_gnews.TestGNews) ... ok
test_get_news_by_location (test_gnews.TestGNews) ... ok
test_get_news_by_site_invalid (test_gnews.TestGNews) ... ok
test_get_news_by_site_valid (test_gnews.TestGNews) ... ok
test_get_news_by_topic (test_gnews.TestGNews) ... ok
test_get_news_more_than_100 (test_gnews.TestGNews) ... /home/hmarshall/projects/hacktoberfest/GNews/./gnews/gnews.py:237: UserWarning: Only searches using the function get_news support date ranges. Review the documentation for _get_news_more_than_100 for a partial workaround. 
Start date and end date will be ignored
  return self._get_news_more_than_100(key)
ok
test_get_top_news (test_gnews.TestGNews) ... ok

----------------------------------------------------------------------
Ran 8 tests in 157.739s

OK
Received test ids from temp file.
Finished running tests!
```