### PR TITLE
docs: add ReadTheDocs documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -250,3 +250,4 @@ dmypy.json
 .prof
 
 # End of https://www.toptal.com/developers/gitignore/api/pycharm,python
+docs/_build/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,14 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: docs/requirements.txt
+    - requirements: requirements.txt

--- a/docs/backends/rss.md
+++ b/docs/backends/rss.md
@@ -1,0 +1,34 @@
+# RSS Backend (Default)
+
+The RSS backend is the default. No API key required.
+
+## How it works
+
+GNews fetches Google News RSS feeds and parses them using `feedparser`. Article URLs are resolved from Google's redirect links to the actual article URLs.
+
+## Article fields
+
+| Field | Description |
+|-------|-------------|
+| `title` | Article title |
+| `description` | Short summary |
+| `published date` | RFC 2822 date string |
+| `url` | Direct article URL |
+| `publisher` | Publisher name/dict |
+
+## Limitations
+
+- Max ~100 results per query
+- No absolute ISO dates (relative strings like "2 hours ago")
+- No thumbnails or favicons
+- Occasionally affected by Google RSS changes
+
+## Usage
+
+```python
+from gnews import GNews
+
+# Default — uses RSS
+g = GNews(max_results=10)
+articles = g.get_news("Python")
+```

--- a/docs/backends/searchapi.md
+++ b/docs/backends/searchapi.md
@@ -1,0 +1,56 @@
+# SearchApi Backend
+
+[SearchApi](https://www.searchapi.io/google-news?utm_source=github&utm_medium=sponsorship&utm_campaign=google_news_api&utm_content=ranahaani_GNews) is an optional backend that replaces RSS with a reliable Google News API.
+
+## Setup
+
+Get a free API key at [searchapi.io](https://www.searchapi.io/google-news?utm_source=github&utm_medium=sponsorship&utm_campaign=google_news_api&utm_content=ranahaani_GNews), then pass it to `GNews`:
+
+```python
+from gnews import GNews
+
+g = GNews(searchapi_key="YOUR_SEARCHAPI_KEY", max_results=10)
+articles = g.get_news("artificial intelligence")
+```
+
+## Benefits over RSS
+
+| Feature | RSS | SearchApi |
+|---------|-----|-----------|
+| Direct article URLs | ✅ (resolved) | ✅ |
+| Absolute ISO dates | ❌ | ✅ |
+| Thumbnails | ❌ | ✅ |
+| Favicons | ❌ | ✅ |
+| Result ranking | ❌ | ✅ |
+| Pagination | ❌ | ✅ |
+| No rate limits | ❌ | ✅ |
+
+## Extra article fields
+
+```python
+{
+    "title": "OpenAI announces new model",
+    "description": "Article snippet...",
+    "published date": "2 hours ago",
+    "iso_date": "2026-06-15T10:00:00Z",   # ← absolute date
+    "url": "https://techcrunch.com/...",
+    "publisher": "TechCrunch",
+    "thumbnail": "data:image/jpeg;base64,...",  # ← article image
+    "favicon": "data:image/png;base64,...",     # ← publisher logo
+    "rank": 1                                   # ← position in results
+}
+```
+
+## Pagination
+
+```python
+g = GNews(searchapi_key="YOUR_KEY", max_results=50)
+
+page1 = g.get_news("Python", page=1)
+page2 = g.get_news("Python", page=2)
+```
+
+## Notes
+
+- `get_top_news()` always uses RSS (SearchApi requires a search query)
+- All other methods (`get_news`, `get_news_by_topic`, `get_news_by_location`, `get_news_by_site`) use SearchApi when a key is provided

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,32 @@
+# Changelog
+
+## 0.6.0 (2026-06-15)
+
+### Added
+- `save_to_json()` and `save_to_csv()` export methods
+- `gnews` CLI with `search`, `top`, `topic`, `site`, `location` commands
+- [SearchApi](https://www.searchapi.io) backend — opt-in via `searchapi_key` parameter
+- `get_full_article()` now uses `trafilatura` via `pip install gnews[fulltext]`
+- Full type hints on all public methods
+- Python 3.12, 3.13, 3.14 support
+- CI matrix across Python 3.10–3.13
+
+### Fixed
+- Removed `logging.basicConfig` from module level — no longer pollutes user logging config
+- Removed dynamic `pip install` anti-pattern from `get_full_article()`
+
+### Changed
+- `get_full_article()` returns `dict` with `text` and `url` keys instead of `newspaper.Article` object
+- Dropped Python 3.8 and 3.9 support (both EOL)
+
+## 0.5.1 (2026-06-15)
+
+- Fix Python 3.8 type hint compatibility (`from __future__ import annotations`)
+
+## 0.5.0 (2026-06-11)
+
+- Initial SearchApi backend integration
+
+## 0.4.3 and earlier
+
+See [GitHub releases](https://github.com/ranahaani/GNews/releases).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,21 @@
+project = "GNews"
+copyright = "2026, Muhammad Abdullah"
+author = "Muhammad Abdullah"
+release = "0.6.0"
+
+extensions = [
+    "myst_parser",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.viewcode",
+]
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build"]
+source_suffix = {".rst": "restructuredtext", ".md": "markdown"}
+
+html_theme = "sphinx_rtd_theme"
+html_static_path = ["_static"]
+html_theme_options = {
+    "logo_only": False,
+    "navigation_depth": 4,
+}

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,37 @@
+# Contributing
+
+Contributions are welcome!
+
+## Setup
+
+```shell
+git clone https://github.com/ranahaani/GNews.git
+cd GNews
+pip install -r requirements.txt
+pip install pytest
+```
+
+## Running tests
+
+```shell
+pytest tests/ -v
+```
+
+## Workflow
+
+1. Fork the repo
+2. Create a feature branch: `git checkout -b feat/my-feature`
+3. Write tests first (TDD)
+4. Implement your change
+5. Ensure all tests pass: `pytest tests/ -v`
+6. Open a Pull Request against `master`
+
+## Code style
+
+- Follow PEP 8
+- Add type hints to all public methods
+- Keep the package lightweight — avoid adding heavy dependencies to core
+
+## Reporting bugs
+
+Open an issue at [github.com/ranahaani/GNews/issues](https://github.com/ranahaani/GNews/issues).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,51 @@
+GNews Documentation
+===================
+
+.. image:: https://img.shields.io/pypi/dm/GNews.svg?style=for-the-badge
+   :target: https://pypistats.org/packages/gnews
+
+.. image:: https://img.shields.io/github/stars/ranahaani/GNews.svg?style=for-the-badge
+   :target: https://github.com/ranahaani/GNews/stargazers
+
+A lightweight Python package that searches Google News and returns structured article data.
+Supports 141+ countries and 41+ languages.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Getting Started
+
+   installation
+   quickstart
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Usage Guide
+
+   usage/search
+   usage/filtering
+   usage/export
+   usage/cli
+   usage/fulltext
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Backends
+
+   backends/rss
+   backends/searchapi
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Reference
+
+   reference/api
+   reference/exceptions
+   reference/countries
+   reference/languages
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Project
+
+   changelog
+   contributing

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,27 @@
+# Installation
+
+## Basic Install
+
+```shell
+pip install gnews
+```
+
+Requires Python 3.10+.
+
+## With Full Article Support
+
+To use `get_full_article()`, install the `fulltext` extra:
+
+```shell
+pip install gnews[fulltext]
+```
+
+This adds [trafilatura](https://trafilatura.readthedocs.io/) for article text extraction.
+
+## Development Install
+
+```shell
+git clone https://github.com/ranahaani/GNews.git
+cd GNews
+pip install -r requirements.txt
+```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,44 @@
+# Quickstart
+
+## Search news
+
+```python
+from gnews import GNews
+
+g = GNews()
+articles = g.get_news("artificial intelligence")
+
+for article in articles:
+    print(article["title"])
+    print(article["url"])
+```
+
+## Top headlines
+
+```python
+g = GNews(max_results=10)
+articles = g.get_top_news()
+```
+
+## Filter by language and country
+
+```python
+g = GNews(language="de", country="DE", max_results=5)
+articles = g.get_news("Bundesliga")
+```
+
+## What you get back
+
+Each article is a dict:
+
+```python
+{
+    "title": "OpenAI announces GPT-5",
+    "description": "OpenAI has released...",
+    "published date": "Mon, 15 Jun 2026 10:00:00 GMT",
+    "url": "https://techcrunch.com/...",
+    "publisher": "TechCrunch"
+}
+```
+
+See [Article Properties](reference/api.md) for the full field reference.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,0 +1,140 @@
+# API Reference
+
+## GNews
+
+```python
+class GNews(
+    language: str = "en",
+    country: str = "US",
+    max_results: int = 100,
+    period: str | None = None,
+    start_date: tuple | datetime | None = None,
+    end_date: tuple | datetime | None = None,
+    exclude_websites: list[str] | None = None,
+    proxy: dict | None = None,
+    searchapi_key: str | None = None,
+)
+```
+
+### Methods
+
+#### get_news(key, page=1)
+
+Search news by keyword.
+
+```python
+articles = g.get_news("OpenAI")
+articles = g.get_news("Python", page=2)  # pagination (SearchApi only)
+```
+
+**Returns:** `list[dict]`
+
+---
+
+#### get_top_news()
+
+Get current top headlines.
+
+```python
+articles = g.get_top_news()
+```
+
+**Returns:** `list[dict]`
+
+---
+
+#### get_news_by_topic(topic)
+
+Get news for a major topic.
+
+```python
+articles = g.get_news_by_topic("TECHNOLOGY")
+```
+
+**Returns:** `list[dict]`
+
+---
+
+#### get_news_by_location(location)
+
+Get news for a city, state, or country.
+
+```python
+articles = g.get_news_by_location("Pakistan")
+```
+
+**Returns:** `list[dict]`
+
+---
+
+#### get_news_by_site(site)
+
+Get news from a specific domain.
+
+```python
+articles = g.get_news_by_site("bbc.com")
+```
+
+**Returns:** `list[dict]`
+
+---
+
+#### get_full_article(url)
+
+Extract full article text. Requires `pip install gnews[fulltext]`.
+
+```python
+article = g.get_full_article("https://example.com/article")
+# {"text": "...", "url": "..."}
+```
+
+**Returns:** `dict` with keys `text`, `url`
+
+**Raises:** `ImportError` if trafilatura not installed, `NetworkError` on failure
+
+---
+
+#### save_to_json(articles, path)
+
+Save articles to a JSON file.
+
+```python
+g.save_to_json(articles, "news.json")
+```
+
+**Returns:** `str` — the output path
+
+---
+
+#### save_to_csv(articles, path)
+
+Save articles to a CSV file.
+
+```python
+g.save_to_csv(articles, "news.csv")
+```
+
+**Returns:** `str` — the output path
+
+---
+
+## Article Properties
+
+### RSS backend fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `title` | str | Article title |
+| `description` | str | Short summary |
+| `published date` | str | RFC 2822 date |
+| `url` | str | Article URL |
+| `publisher` | str/dict | Publisher info |
+
+### SearchApi extra fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `iso_date` | str | ISO 8601 date |
+| `thumbnail` | str | Article image (base64) |
+| `favicon` | str | Publisher logo (base64) |
+| `rank` | int | Position in results |

--- a/docs/reference/countries.md
+++ b/docs/reference/countries.md
@@ -1,0 +1,80 @@
+# Supported Countries
+
+Pass the country code or full name to `GNews(country=...)`.
+
+```python
+g = GNews(country="PK")   # Pakistan
+g = GNews(country="US")   # United States
+```
+
+| Country | Code |
+|---------|------|
+| Australia | AU |
+| Argentina | AR |
+| Austria | AT |
+| Bangladesh | BD |
+| Belgium | BE |
+| Botswana | BW |
+| Brazil | BR |
+| Bulgaria | BG |
+| Canada | CA |
+| Chile | CL |
+| China | CN |
+| Colombia | CO |
+| Cuba | CU |
+| Czech Republic | CZ |
+| Egypt | EG |
+| Ethiopia | ET |
+| France | FR |
+| Germany | DE |
+| Ghana | GH |
+| Greece | GR |
+| Hong Kong | HK |
+| Hungary | HU |
+| India | IN |
+| Indonesia | ID |
+| Ireland | IE |
+| Israel | IL |
+| Italy | IT |
+| Japan | JP |
+| Kenya | KE |
+| Latvia | LV |
+| Lebanon | LB |
+| Lithuania | LT |
+| Malaysia | MY |
+| Mexico | MX |
+| Morocco | MA |
+| Namibia | NA |
+| Netherlands | NL |
+| New Zealand | NZ |
+| Nigeria | NG |
+| Norway | NO |
+| Pakistan | PK |
+| Peru | PE |
+| Philippines | PH |
+| Poland | PL |
+| Portugal | PT |
+| Republic of Korea | KR |
+| Romania | RO |
+| Russia | RU |
+| Saudi Arabia | SA |
+| Senegal | SN |
+| Serbia | RS |
+| Singapore | SG |
+| Slovakia | SK |
+| Slovenia | SI |
+| South Africa | ZA |
+| Sweden | SE |
+| Switzerland | CH |
+| Taiwan | TW |
+| Tanzania | TZ |
+| Thailand | TH |
+| Turkey | TR |
+| Uganda | UG |
+| Ukraine | UA |
+| United Arab Emirates | AE |
+| United Kingdom | GB |
+| United States | US |
+| Venezuela | VE |
+| Vietnam | VN |
+| Zimbabwe | ZW |

--- a/docs/reference/exceptions.md
+++ b/docs/reference/exceptions.md
@@ -1,0 +1,55 @@
+# Exceptions
+
+All exceptions are in `gnews.exceptions`.
+
+```python
+from gnews.exceptions import NetworkError, InvalidConfigError, RateLimitError
+```
+
+## NetworkError
+
+Raised when an article or feed cannot be fetched.
+
+```python
+from gnews.exceptions import NetworkError
+
+try:
+    articles = g.get_news("Python")
+except NetworkError as e:
+    print(f"Network error: {e}")
+```
+
+## InvalidConfigError
+
+Raised when invalid parameters are passed.
+
+```python
+g = GNews(max_results=0)  # raises InvalidConfigError
+g.exclude_websites = "yahoo.com"  # raises InvalidConfigError (must be list)
+```
+
+## RateLimitError
+
+Raised when Google News rate-limits the RSS feed (HTTP 429).
+
+```python
+from gnews.exceptions import RateLimitError
+
+try:
+    articles = g.get_news("Python")
+except RateLimitError:
+    print("Rate limited — try again later or use SearchApi backend")
+```
+
+## GNewsException
+
+Base class for all GNews exceptions.
+
+```python
+from gnews.exceptions import GNewsException
+
+try:
+    articles = g.get_news("Python")
+except GNewsException as e:
+    print(f"GNews error: {e}")
+```

--- a/docs/reference/languages.md
+++ b/docs/reference/languages.md
@@ -1,0 +1,50 @@
+# Supported Languages
+
+Pass the language code or full name to `GNews(language=...)`.
+
+```python
+g = GNews(language="ur")      # Urdu
+g = GNews(language="english") # also works
+```
+
+| Language | Code |
+|----------|------|
+| Arabic | ar |
+| Bengali | bn |
+| Bulgarian | bg |
+| Chinese Simplified | zh-Hans |
+| Chinese Traditional | zh-Hant |
+| Czech | cs |
+| Dutch | nl |
+| English | en |
+| French | fr |
+| German | de |
+| Greek | el |
+| Hebrew | he |
+| Hindi | hi |
+| Hungarian | hu |
+| Indonesian | id |
+| Italian | it |
+| Japanese | ja |
+| Korean | ko |
+| Latvian | lv |
+| Lithuanian | lt |
+| Malayalam | ml |
+| Marathi | mr |
+| Norwegian | no |
+| Polish | pl |
+| Portuguese (Brazil) | pt-419 |
+| Portuguese (Portugal) | pt-150 |
+| Romanian | ro |
+| Russian | ru |
+| Serbian | sr |
+| Slovak | sk |
+| Slovenian | sl |
+| Spanish | es-419 |
+| Swedish | sv |
+| Tamil | ta |
+| Telugu | te |
+| Thai | th |
+| Turkish | tr |
+| Ukrainian | uk |
+| Vietnamese | vi |

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx>=7.0
+sphinx-rtd-theme>=2.0
+myst-parser>=2.0

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -1,0 +1,59 @@
+# CLI Usage
+
+GNews includes a command-line interface available after `pip install gnews`.
+
+## Commands
+
+### search
+
+```shell
+gnews search "artificial intelligence"
+gnews search "Pakistan" --lang ur --country PK --max 5
+gnews search "OpenAI" --json
+```
+
+### top
+
+```shell
+gnews top
+gnews top --max 20 --json
+```
+
+### topic
+
+```shell
+gnews topic TECHNOLOGY
+gnews topic BUSINESS --max 10 --json
+```
+
+### site
+
+```shell
+gnews site bbc.com
+gnews site cnn.com --max 5 --json
+```
+
+### location
+
+```shell
+gnews location Pakistan
+gnews location "New York" --json
+```
+
+## Common options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--lang` | `en` | Language code |
+| `--country` | `US` | Country code |
+| `--max` | `10` | Max results |
+| `--json` | off | Output as JSON |
+
+## JSON output
+
+The `--json` flag outputs valid JSON to stdout, making it easy to pipe into other tools:
+
+```shell
+gnews search "AI" --json | python3 -m json.tool
+gnews top --json | jq '.[0].title'
+```

--- a/docs/usage/export.md
+++ b/docs/usage/export.md
@@ -1,0 +1,51 @@
+# Exporting Results
+
+## Save to JSON
+
+```python
+from gnews import GNews
+
+g = GNews(max_results=20)
+articles = g.get_news("artificial intelligence")
+
+path = g.save_to_json(articles, "news.json")
+print(f"Saved to {path}")
+```
+
+Output format:
+
+```json
+[
+  {
+    "title": "AI Breakthrough",
+    "description": "Researchers have...",
+    "published date": "Mon, 15 Jun 2026 10:00:00 GMT",
+    "url": "https://example.com/ai",
+    "publisher": "TechNews"
+  }
+]
+```
+
+## Save to CSV
+
+```python
+path = g.save_to_csv(articles, "news.csv")
+```
+
+The CSV header is auto-detected from the article fields. Compatible with Excel, pandas, and any CSV reader.
+
+```python
+import pandas as pd
+
+df = pd.read_csv("news.csv")
+print(df.head())
+```
+
+## Both methods return the path
+
+```python
+json_path = g.save_to_json(articles, "/tmp/news.json")
+csv_path = g.save_to_csv(articles, "/tmp/news.csv")
+```
+
+No extra dependencies required — uses Python stdlib `json` and `csv`.

--- a/docs/usage/filtering.md
+++ b/docs/usage/filtering.md
@@ -1,0 +1,55 @@
+# Filtering Results
+
+## Initialization parameters
+
+```python
+from gnews import GNews
+
+g = GNews(
+    language="en",       # Language code (default: "en")
+    country="US",        # Country code (default: "US")
+    max_results=10,      # Max articles to return (default: 100)
+    period="7d",         # Time period: 1h, 7d, 6m, 1y
+    start_date=(2026, 1, 1),   # Or datetime object
+    end_date=(2026, 6, 1),
+    exclude_websites=["yahoo.com", "cnn.com"],
+    proxy={"https": "https://your_proxy_address"},
+)
+```
+
+## Update after creation
+
+```python
+g.language = "fr"
+g.country = "FR"
+g.max_results = 5
+g.period = "1d"
+g.start_date = (2026, 1, 1)
+g.end_date = (2026, 6, 1)
+g.exclude_websites = ["yahoo.com"]
+```
+
+## Period format
+
+| Value | Meaning |
+|-------|---------|
+| `12h` | Last 12 hours |
+| `7d` | Last 7 days |
+| `6m` | Last 6 months |
+| `1y` | Last 1 year |
+
+## Date range
+
+```python
+from datetime import datetime
+
+g = GNews(
+    start_date=(2026, 1, 1),
+    end_date=(2026, 6, 1),
+)
+# Or using datetime objects
+g.start_date = datetime(2026, 1, 1)
+g.end_date = datetime(2026, 6, 1)
+```
+
+> **Note:** Date ranges only work with `get_news()`. Other methods ignore start/end dates.

--- a/docs/usage/fulltext.md
+++ b/docs/usage/fulltext.md
@@ -1,0 +1,52 @@
+# Getting Full Article Text
+
+## Install
+
+Full article extraction requires the `fulltext` extra:
+
+```shell
+pip install gnews[fulltext]
+```
+
+## Usage
+
+```python
+from gnews import GNews
+
+g = GNews(max_results=5)
+articles = g.get_news("OpenAI")
+
+article = g.get_full_article(articles[0]["url"])
+print(article["text"])   # full article text
+print(article["url"])    # original URL
+```
+
+## Return value
+
+```python
+{
+    "text": "Full article text...",
+    "url": "https://example.com/article"
+}
+```
+
+## Error handling
+
+```python
+from gnews.exceptions import NetworkError
+
+try:
+    article = g.get_full_article(url)
+except NetworkError as e:
+    print(f"Could not fetch article: {e}")
+except ImportError:
+    print("Run: pip install gnews[fulltext]")
+```
+
+## Limitations
+
+- **Paywalls**: Articles behind paywalls cannot be extracted
+- **JS-heavy sites**: Some modern sites block plain HTTP requests
+- **Bot detection**: Sites using Cloudflare may block extraction
+
+If `get_full_article()` fails consistently on a site, navigate to the URL directly in your browser.

--- a/docs/usage/search.md
+++ b/docs/usage/search.md
@@ -1,0 +1,37 @@
+# Searching News
+
+## By keyword
+
+```python
+from gnews import GNews
+
+g = GNews(max_results=10)
+articles = g.get_news("Pakistan")
+```
+
+## Top headlines
+
+```python
+articles = g.get_top_news()
+```
+
+## By topic
+
+```python
+articles = g.get_news_by_topic("TECHNOLOGY")
+```
+
+Available topics: `WORLD`, `NATION`, `BUSINESS`, `TECHNOLOGY`, `ENTERTAINMENT`, `SPORTS`, `SCIENCE`, `HEALTH`, `POLITICS`, `CELEBRITIES`, `TV`, `MUSIC`, `MOVIES`, `THEATER`, `SOCCER`, `CYCLING`, `MOTOR SPORTS`, `TENNIS`, `COMBAT SPORTS`, `BASKETBALL`, `BASEBALL`, `FOOTBALL`, `SPORTS BETTING`, `WATER SPORTS`, `HOCKEY`, `GOLF`, `CRICKET`, `RUGBY`, `ECONOMY`, `PERSONAL FINANCE`, `FINANCE`, `DIGITAL CURRENCIES`, `MOBILE`, `ENERGY`, `GAMING`, `INTERNET SECURITY`, `GADGETS`, `VIRTUAL REALITY`, `ROBOTICS`, `NUTRITION`, `PUBLIC HEALTH`, `MENTAL HEALTH`, `MEDICINE`, `SPACE`, `WILDLIFE`, `ENVIRONMENT`, `NEUROSCIENCE`, `PHYSICS`, `GEOLOGY`, `PALEONTOLOGY`, `SOCIAL SCIENCES`, `EDUCATION`, `JOBS`, `ONLINE EDUCATION`, `HIGHER EDUCATION`, `VEHICLES`, `ARTS-DESIGN`, `BEAUTY`, `FOOD`, `TRAVEL`, `SHOPPING`, `HOME`, `OUTDOORS`, `FASHION`
+
+## By location
+
+```python
+articles = g.get_news_by_location("Pakistan")
+articles = g.get_news_by_location("Karachi")
+```
+
+## By site
+
+```python
+articles = g.get_news_by_site("bbc.com")
+```


### PR DESCRIPTION
## Summary
Full ReadTheDocs documentation covering all v0.6.0 features.

## Structure
```
docs/
├── installation.md       — pip install gnews / gnews[fulltext]
├── quickstart.md         — 5-minute getting started
├── usage/
│   ├── search.md         — all search methods
│   ├── filtering.md      — language, country, date, period
│   ├── export.md         — save_to_json / save_to_csv
│   ├── cli.md            — gnews CLI reference
│   └── fulltext.md       — get_full_article()
├── backends/
│   ├── rss.md            — default RSS backend
│   └── searchapi.md      — SearchApi backend
├── reference/
│   ├── api.md            — full API reference
│   ├── exceptions.md     — error handling
│   ├── countries.md      — 60+ supported countries
│   └── languages.md      — 40+ supported languages
├── changelog.md
└── contributing.md
```

## Next steps after merge
1. Go to https://readthedocs.org
2. Sign in with GitHub
3. Import project: ranahaani/GNews
4. Build triggers automatically on every master push

## Test plan
- [x] Local Sphinx build passes with no errors
- [x] All pages linked in table of contents
- [x] `.readthedocs.yaml` config present