### PR TITLE
feat(async): add async methods for all search operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@
             <li><a href="#getting-full-article">Getting Full Article 📰</a></li>
             <li><a href="#export-results">Export Results 💾</a></li>
             <li><a href="#cli-usage">CLI Usage 💻</a></li>
+            <li><a href="#async-support">Async Support ⚡</a></li>
          </ul>
       </li>
       <li><a href="#searchapi-integration">SearchApi Integration 🔍</a></li>
@@ -493,6 +494,39 @@ articles = google_news.get_news("Python", page=2)
 
 <!-- ToDo -->
 
+## Async Support
+
+All search methods have async equivalents — no new dependencies required:
+
+```python
+import asyncio
+from gnews import GNews
+
+g = GNews(max_results=10)
+
+# Single async query
+articles = asyncio.run(g.get_news_async("AI"))
+
+# Fetch multiple topics concurrently
+async def main():
+    ai, python, pakistan = await asyncio.gather(
+        g.get_news_async("AI"),
+        g.get_news_async("Python"),
+        g.get_news_async("Pakistan"),
+    )
+    return ai, python, pakistan
+
+asyncio.run(main())
+```
+
+| Async method | Sync equivalent |
+|---|---|
+| `get_news_async(key, page=1)` | `get_news()` |
+| `get_top_news_async()` | `get_top_news()` |
+| `get_news_by_topic_async(topic)` | `get_news_by_topic()` |
+| `get_news_by_location_async(location)` | `get_news_by_location()` |
+| `get_news_by_site_async(site)` | `get_news_by_site()` |
+
 ## Todo
 
 - Save to MongoDB
@@ -500,7 +534,7 @@ articles = google_news.get_news("Python", page=2)
 - ~~Save to JSON~~ ✅
 - ~~Save to .CSV file~~ ✅
 - ~~More than 100 articles~~ ✅
-- Async support
+- ~~Async support~~ ✅
 - FastAPI wrapper
 
 <!-- ROADMAP -->

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.7.0 (2026-06-15)
+
+### Added
+- Async methods: `get_news_async()`, `get_top_news_async()`, `get_news_by_topic_async()`, `get_news_by_location_async()`, `get_news_by_site_async()`
+- Works with both RSS and SearchApi backends
+- No new dependencies — uses stdlib `asyncio`
+
 ## 0.6.0 (2026-06-15)
 
 ### Added

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,7 @@ Supports 141+ countries and 41+ languages.
    usage/export
    usage/cli
    usage/fulltext
+   usage/async
 
 .. toctree::
    :maxdepth: 2

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -94,6 +94,41 @@ article = g.get_full_article("https://example.com/article")
 
 ---
 
+#### get_news_async(key, page=1)
+
+Async version of `get_news()`.
+
+```python
+articles = await g.get_news_async("OpenAI")
+articles = await g.get_news_async("Python", page=2)
+```
+
+---
+
+#### get_top_news_async()
+
+Async version of `get_top_news()`.
+
+---
+
+#### get_news_by_topic_async(topic)
+
+Async version of `get_news_by_topic()`.
+
+---
+
+#### get_news_by_location_async(location)
+
+Async version of `get_news_by_location()`.
+
+---
+
+#### get_news_by_site_async(site)
+
+Async version of `get_news_by_site()`.
+
+---
+
 #### save_to_json(articles, path)
 
 Save articles to a JSON file.

--- a/docs/usage/async.md
+++ b/docs/usage/async.md
@@ -1,0 +1,89 @@
+# Async Support
+
+All search methods have async equivalents. No extra dependencies — uses Python's built-in `asyncio`.
+
+## Basic usage
+
+```python
+import asyncio
+from gnews import GNews
+
+g = GNews(max_results=10)
+
+articles = asyncio.run(g.get_news_async("artificial intelligence"))
+```
+
+## Concurrent queries
+
+The real power of async is fetching multiple queries simultaneously:
+
+```python
+import asyncio
+from gnews import GNews
+
+g = GNews(max_results=10)
+
+async def main():
+    ai, python, pakistan = await asyncio.gather(
+        g.get_news_async("AI"),
+        g.get_news_async("Python"),
+        g.get_news_async("Pakistan"),
+    )
+    print(f"AI: {len(ai)} articles")
+    print(f"Python: {len(python)} articles")
+    print(f"Pakistan: {len(pakistan)} articles")
+
+asyncio.run(main())
+```
+
+## Available async methods
+
+| Async method | Sync equivalent |
+|---|---|
+| `get_news_async(key, page=1)` | `get_news()` |
+| `get_top_news_async()` | `get_top_news()` |
+| `get_news_by_topic_async(topic)` | `get_news_by_topic()` |
+| `get_news_by_location_async(location)` | `get_news_by_location()` |
+| `get_news_by_site_async(site)` | `get_news_by_site()` |
+
+## With SearchApi backend
+
+Works the same with the SearchApi backend:
+
+```python
+g = GNews(searchapi_key="YOUR_KEY", max_results=10)
+
+async def main():
+    results = await asyncio.gather(
+        g.get_news_async("OpenAI"),
+        g.get_news_async("Anthropic"),
+        g.get_news_async("Google AI"),
+    )
+    return results
+
+asyncio.run(main())
+```
+
+## FastAPI integration
+
+```python
+from fastapi import FastAPI
+from gnews import GNews
+
+app = FastAPI()
+g = GNews(max_results=10)
+
+@app.get("/news/{query}")
+async def get_news(query: str):
+    return await g.get_news_async(query)
+
+@app.get("/top")
+async def get_top():
+    return await g.get_top_news_async()
+```
+
+## Notes
+
+- Sync methods (`get_news()`, etc.) continue to work exactly as before
+- Async methods run the sync implementation in a thread pool — safe for I/O-bound work
+- All parameters and return values are identical to their sync counterparts

--- a/gnews/gnews.py
+++ b/gnews/gnews.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import asyncio
 import csv
+import functools
 import json
 import logging
 import urllib.request
@@ -314,6 +316,25 @@ class GNews:
             key = "site:{}".format(site)
             return self.get_news(key)
         raise InvalidConfigError("Site domain cannot be empty.")
+
+    async def _run_in_executor(self, func, *args):
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(None, functools.partial(func, *args))
+
+    async def get_news_async(self, key: str, page: int = 1) -> list[dict]:
+        return await self._run_in_executor(self.get_news, key, page)
+
+    async def get_top_news_async(self) -> list[dict]:
+        return await self._run_in_executor(self.get_top_news)
+
+    async def get_news_by_topic_async(self, topic: str) -> list[dict]:
+        return await self._run_in_executor(self.get_news_by_topic, topic)
+
+    async def get_news_by_location_async(self, location: str) -> list[dict]:
+        return await self._run_in_executor(self.get_news_by_location, location)
+
+    async def get_news_by_site_async(self, site: str) -> list[dict]:
+        return await self._run_in_executor(self.get_news_by_site, site)
 
     def save_to_json(self, articles: list[dict], path: str) -> str:
         with open(path, "w", encoding="utf-8") as f:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='gnews',
-    version='0.6.0',
+    version='0.7.0',
     # setup_requires=['setuptools_scm'],
     # use_scm_version={
     #     "local_scheme": "no-local-version"

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,0 +1,125 @@
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from gnews import GNews
+
+
+SAMPLE_ARTICLES = [
+    {
+        "title": "AI Breakthrough",
+        "description": "New model released.",
+        "published date": "Mon, 10 Jun 2026 10:00:00 GMT",
+        "url": "https://example.com/ai",
+        "publisher": "TechNews",
+    },
+    {
+        "title": "Stock Market Up",
+        "description": "Markets rally.",
+        "published date": "Mon, 10 Jun 2026 11:00:00 GMT",
+        "url": "https://example.com/stocks",
+        "publisher": "FinanceDaily",
+    },
+]
+
+
+def run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+class TestAsyncGetNews(unittest.TestCase):
+    @patch("gnews.GNews.get_news", return_value=SAMPLE_ARTICLES)
+    def test_async_get_news_returns_list(self, mock):
+        g = GNews(max_results=2)
+        result = run(g.get_news_async("AI"))
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+
+    @patch("gnews.GNews.get_news", return_value=SAMPLE_ARTICLES)
+    def test_async_get_news_title(self, mock):
+        g = GNews(max_results=2)
+        result = run(g.get_news_async("AI"))
+        self.assertEqual(result[0]["title"], "AI Breakthrough")
+
+    @patch("gnews.GNews.get_news", return_value=SAMPLE_ARTICLES)
+    def test_async_get_news_passes_query(self, mock):
+        g = GNews(max_results=2)
+        run(g.get_news_async("Python"))
+        mock.assert_called_once_with("Python", 1)
+
+    @patch("gnews.GNews.get_news", return_value=SAMPLE_ARTICLES)
+    def test_async_get_news_passes_page(self, mock):
+        g = GNews(max_results=2)
+        run(g.get_news_async("Python", page=3))
+        mock.assert_called_once_with("Python", 3)
+
+
+class TestAsyncGetTopNews(unittest.TestCase):
+    @patch("gnews.GNews.get_top_news", return_value=SAMPLE_ARTICLES)
+    def test_async_get_top_news_returns_list(self, mock):
+        g = GNews(max_results=2)
+        result = run(g.get_top_news_async())
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+
+    @patch("gnews.GNews.get_top_news", return_value=SAMPLE_ARTICLES)
+    def test_async_get_top_news_calls_sync(self, mock):
+        g = GNews()
+        run(g.get_top_news_async())
+        mock.assert_called_once()
+
+
+class TestAsyncGetNewsByTopic(unittest.TestCase):
+    @patch("gnews.GNews.get_news_by_topic", return_value=SAMPLE_ARTICLES)
+    def test_returns_list(self, mock):
+        g = GNews()
+        result = run(g.get_news_by_topic_async("TECHNOLOGY"))
+        self.assertIsInstance(result, list)
+
+    @patch("gnews.GNews.get_news_by_topic", return_value=SAMPLE_ARTICLES)
+    def test_passes_topic(self, mock):
+        g = GNews()
+        run(g.get_news_by_topic_async("BUSINESS"))
+        mock.assert_called_once_with("BUSINESS")
+
+
+class TestAsyncGetNewsByLocation(unittest.TestCase):
+    @patch("gnews.GNews.get_news_by_location", return_value=SAMPLE_ARTICLES)
+    def test_returns_list(self, mock):
+        g = GNews()
+        result = run(g.get_news_by_location_async("Pakistan"))
+        self.assertIsInstance(result, list)
+
+    @patch("gnews.GNews.get_news_by_location", return_value=SAMPLE_ARTICLES)
+    def test_passes_location(self, mock):
+        g = GNews()
+        run(g.get_news_by_location_async("India"))
+        mock.assert_called_once_with("India")
+
+
+class TestAsyncGetNewsBySite(unittest.TestCase):
+    @patch("gnews.GNews.get_news_by_site", return_value=SAMPLE_ARTICLES)
+    def test_returns_list(self, mock):
+        g = GNews()
+        result = run(g.get_news_by_site_async("bbc.com"))
+        self.assertIsInstance(result, list)
+
+    @patch("gnews.GNews.get_news_by_site", return_value=SAMPLE_ARTICLES)
+    def test_passes_site(self, mock):
+        g = GNews()
+        run(g.get_news_by_site_async("cnn.com"))
+        mock.assert_called_once_with("cnn.com")
+
+
+class TestAsyncConcurrent(unittest.TestCase):
+    @patch("gnews.GNews.get_news", return_value=SAMPLE_ARTICLES)
+    def test_gather_multiple_queries(self, mock):
+        g = GNews()
+        results = run(asyncio.gather(
+            g.get_news_async("AI"),
+            g.get_news_async("Python"),
+            g.get_news_async("Pakistan"),
+        ))
+        self.assertEqual(len(results), 3)
+        for r in results:
+            self.assertIsInstance(r, list)


### PR DESCRIPTION
## Summary
Adds async versions of all search methods — zero new dependencies (stdlib `asyncio` + `concurrent.futures` only).

## New methods

| Async method | Sync equivalent |
|---|---|
| `get_news_async(key, page=1)` | `get_news()` |
| `get_top_news_async()` | `get_top_news()` |
| `get_news_by_topic_async(topic)` | `get_news_by_topic()` |
| `get_news_by_location_async(location)` | `get_news_by_location()` |
| `get_news_by_site_async(site)` | `get_news_by_site()` |

## Usage

```python
import asyncio
from gnews import GNews

g = GNews(max_results=10)

# Single query
articles = asyncio.run(g.get_news_async("AI"))

# Concurrent queries — fetch 3 topics simultaneously
async def main():
    results = await asyncio.gather(
        g.get_news_async("AI"),
        g.get_news_async("Python"),
        g.get_news_async("Pakistan"),
    )
    return results

results = asyncio.run(main())
```

## Implementation
Uses `loop.run_in_executor()` to run sync methods in a thread pool — no blocking of the event loop, no new dependencies, existing sync API fully unchanged.

## Test plan
- [x] 13 async tests covering all 5 methods
- [x] Concurrent `asyncio.gather()` test
- [x] 73 total tests passing, zero regression

Closes #134