### PR TITLE
fix(proxy): forward proxy to Playwright during URL resolution (v0.8.1)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.8.1 (2026-06-18)
+
+### Fixed
+- Proxy now correctly forwarded to Playwright during URL resolution — previously Playwright launched Chromium without any proxy, bypassing the user's configured proxy entirely
+- `resolve_url()` and `_resolve_with_playwright()` now accept a `proxies` parameter
+- `process_url()` now passes `proxies` through to `resolve_url()`
+- urllib-style proxy dict (`{"https": "http://host:port"}`) is automatically converted to Playwright's format (`{"server": "http://host:port"}`)
+
 ## 0.8.0 (2026-06-15)
 
 ### Added

--- a/docs/usage/url-resolution.md
+++ b/docs/usage/url-resolution.md
@@ -61,14 +61,34 @@ articles = g.get_news("AI")
 print(articles[0]['url'])  # always a real URL
 ```
 
+## Proxy support
+
+If your environment requires a proxy, pass it to `GNews` — it will be used for both RSS fetching **and** Playwright URL resolution:
+
+```python
+g = GNews(
+    max_results=5,
+    proxy={"https": "http://myproxy.example.com:8080"}
+)
+articles = g.get_news("artificial intelligence")
+```
+
+Prior to 0.8.1, the proxy was applied to RSS fetching but silently bypassed during Playwright URL resolution. This is now fixed.
+
 ## Manual resolution
 
-You can also resolve individual URLs directly:
+You can also resolve individual URLs directly, with optional proxy:
 
 ```python
 from gnews.utils.utils import resolve_url
 
 google_url = "https://news.google.com/rss/articles/CBMi..."
+
+# Without proxy
 real_url = resolve_url(google_url)
+
+# With proxy
+real_url = resolve_url(google_url, proxies={"https": "http://myproxy:8080"})
+
 print(real_url)
 ```

--- a/gnews/utils/utils.py
+++ b/gnews/utils/utils.py
@@ -17,7 +17,7 @@ def country_mapping(country):
     return AVAILABLE_COUNTRIES.get(country)
 
 
-def _resolve_with_playwright(url: str) -> str | None:
+def _resolve_with_playwright(url: str, proxies: dict | None = None) -> str | None:
     try:
         from playwright.sync_api import sync_playwright, TimeoutError as PWTimeout
     except ImportError:
@@ -26,10 +26,20 @@ def _resolve_with_playwright(url: str) -> str | None:
     try:
         # Convert RSS URL to article URL for Playwright to follow JS redirect
         navigate_url = url.replace('/rss/articles/', '/articles/').split('?')[0]
+
+        # Convert urllib-style proxy dict {"https": "http://host:port"}
+        # to Playwright proxy format {"server": "http://host:port"}
+        playwright_proxy = None
+        if proxies:
+            server = proxies.get("https") or proxies.get("http")
+            if server:
+                playwright_proxy = {"server": server}
+
         with sync_playwright() as p:
             browser = p.chromium.launch(headless=True, args=["--no-sandbox", "--disable-dev-shm-usage"])
             context = browser.new_context(
-                user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+                user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+                proxy=playwright_proxy,
             )
             page = context.new_page()
             page.goto(navigate_url, wait_until="domcontentloaded", timeout=15000)
@@ -48,12 +58,12 @@ def _resolve_with_playwright(url: str) -> str | None:
         return None
 
 
-def resolve_url(url: str) -> str:
+def resolve_url(url: str, proxies: dict | None = None) -> str:
     if "news.google.com" not in url:
         return url
     try:
         from playwright.sync_api import sync_playwright  # noqa: F401
-        resolved = _resolve_with_playwright(url)
+        resolved = _resolve_with_playwright(url, proxies=proxies)
         return resolved if resolved else url
     except ImportError:
         return url
@@ -66,7 +76,7 @@ def process_url(item, exclude_websites, proxies=None):
         return
     url = item.get('link')
     if re.match(GOOGLE_NEWS_REGEX, url):
-        resolved = resolve_url(url)
+        resolved = resolve_url(url, proxies=proxies)
         if resolved != url:
             return resolved
         # fallback: try HEAD redirect (may still work in some environments)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='gnews',
-    version='0.8.0',
+    version='0.8.1',
     # setup_requires=['setuptools_scm'],
     # use_scm_version={
     #     "local_scheme": "no-local-version"

--- a/tests/test_url_resolver.py
+++ b/tests/test_url_resolver.py
@@ -3,6 +3,7 @@ from unittest.mock import patch, MagicMock
 
 GOOGLE_NEWS_URL = "https://news.google.com/rss/articles/CBMirwFBVV95cUxQ"
 REAL_URL = "https://www.washingtonpost.com/politics/2026/06/15/article"
+PROXY = {"https": "http://myproxy.example.com:8080", "http": "http://myproxy.example.com:8080"}
 
 
 class TestResolveUrl(unittest.TestCase):
@@ -30,7 +31,14 @@ class TestResolveUrl(unittest.TestCase):
         from gnews.utils.utils import resolve_url
         result = resolve_url(GOOGLE_NEWS_URL)
         self.assertEqual(result, REAL_URL)
-        mock_resolve.assert_called_once_with(GOOGLE_NEWS_URL)
+        mock_resolve.assert_called_once_with(GOOGLE_NEWS_URL, proxies=None)
+
+    @patch("gnews.utils.utils._resolve_with_playwright", return_value=REAL_URL)
+    def test_proxy_forwarded_to_playwright(self, mock_resolve):
+        from gnews.utils.utils import resolve_url
+        result = resolve_url(GOOGLE_NEWS_URL, proxies=PROXY)
+        self.assertEqual(result, REAL_URL)
+        mock_resolve.assert_called_once_with(GOOGLE_NEWS_URL, proxies=PROXY)
 
     @patch("gnews.utils.utils._resolve_with_playwright", return_value=None)
     def test_falls_back_to_original_on_failure(self, mock_resolve):
@@ -72,3 +80,63 @@ class TestResolveWithPlaywright(unittest.TestCase):
             mock_pw.return_value.__enter__.return_value = mock_instance
             result = _resolve_with_playwright(GOOGLE_NEWS_URL)
             self.assertEqual(result, REAL_URL)
+
+    def test_proxy_passed_to_playwright_context(self):
+        from gnews.utils.utils import _resolve_with_playwright
+
+        mock_page = MagicMock()
+        mock_page.url = REAL_URL
+        mock_context = MagicMock()
+        mock_context.new_page.return_value = mock_page
+        mock_browser = MagicMock()
+        mock_browser.new_context.return_value = mock_context
+
+        with patch("playwright.sync_api.sync_playwright") as mock_pw:
+            mock_instance = MagicMock()
+            mock_instance.chromium.launch.return_value = mock_browser
+            mock_pw.return_value.__enter__.return_value = mock_instance
+
+            _resolve_with_playwright(GOOGLE_NEWS_URL, proxies=PROXY)
+
+            kwargs = mock_browser.new_context.call_args.kwargs
+            self.assertEqual(kwargs["proxy"], {"server": "http://myproxy.example.com:8080"})
+
+    def test_no_proxy_passes_none_to_context(self):
+        from gnews.utils.utils import _resolve_with_playwright
+
+        mock_page = MagicMock()
+        mock_page.url = REAL_URL
+        mock_context = MagicMock()
+        mock_context.new_page.return_value = mock_page
+        mock_browser = MagicMock()
+        mock_browser.new_context.return_value = mock_context
+
+        with patch("playwright.sync_api.sync_playwright") as mock_pw:
+            mock_instance = MagicMock()
+            mock_instance.chromium.launch.return_value = mock_browser
+            mock_pw.return_value.__enter__.return_value = mock_instance
+
+            _resolve_with_playwright(GOOGLE_NEWS_URL)
+
+            kwargs = mock_browser.new_context.call_args.kwargs
+            self.assertIsNone(kwargs["proxy"])
+
+    def test_http_only_proxy_used_as_fallback(self):
+        from gnews.utils.utils import _resolve_with_playwright
+
+        mock_page = MagicMock()
+        mock_page.url = REAL_URL
+        mock_context = MagicMock()
+        mock_context.new_page.return_value = mock_page
+        mock_browser = MagicMock()
+        mock_browser.new_context.return_value = mock_context
+
+        with patch("playwright.sync_api.sync_playwright") as mock_pw:
+            mock_instance = MagicMock()
+            mock_instance.chromium.launch.return_value = mock_browser
+            mock_pw.return_value.__enter__.return_value = mock_instance
+
+            _resolve_with_playwright(GOOGLE_NEWS_URL, proxies={"http": "http://proxy:3128"})
+
+            kwargs = mock_browser.new_context.call_args.kwargs
+            self.assertEqual(kwargs["proxy"], {"server": "http://proxy:3128"})


### PR DESCRIPTION
## Bug

When a user configured `GNews(proxy={...})`, it was correctly applied to RSS fetching via `urllib.request.ProxyHandler` but **silently bypassed** during Playwright URL resolution.

Playwright launched Chromium without any proxy, meaning the real server IP was exposed to Google even for users who had explicitly configured a proxy — critical for server deployments using proxy rotation to avoid IP blocks.

### Broken call chain (before fix)

```python
resolved = resolve_url(url)              # proxy NOT passed ❌
_resolve_with_playwright(url)            # proxy NOT passed ❌
browser.new_context(user_agent="...")    # no proxy in Chromium ❌
```

## Fix

- `_resolve_with_playwright(url, proxies=None)` — accepts proxy, converts urllib dict `{"https": "http://host:port"}` to Playwright format `{"server": "http://host:port"}`
- `resolve_url(url, proxies=None)` — accepts and forwards proxy
- `process_url(...)` — passes proxies through to `resolve_url()`

## Tests

4 new tests — all 11 pass:

- `test_proxy_forwarded_to_playwright`
- `test_proxy_passed_to_playwright_context`
- `test_no_proxy_passes_none_to_context`
- `test_http_only_proxy_used_as_fallback`

## Usage

```python
g = GNews(
    max_results=5,
    proxy={"https": "http://myproxy.example.com:8080"}
)
# Proxy now applied to both RSS fetch AND Playwright URL resolution
articles = g.get_news("AI")
```

Bumps `0.8.0` → `0.8.1`